### PR TITLE
replace parseQuery with getOptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var marked = require('marked');
 var highlight = require('highlight.js');
 
 module.exports = function(source) {
-    var query = loaderUtils.parseQuery(this.query);
+    var query = loaderUtils.getOptions(this);
     var options = {
         renderer: new marked.Renderer(),
         gfm: true,


### PR DESCRIPTION
loaderUtils.parseQuery() will be removed, see https://github.com/webpack/loader-utils/issues/56